### PR TITLE
Add climada_contains() function

### DIFF
--- a/code/helper_functions/climada_contains.m
+++ b/code/helper_functions/climada_contains.m
@@ -1,0 +1,38 @@
+function TF=climada_contains(str,pattern)
+% climada template
+% MODULE:
+%   core
+% NAME:
+%   climada_contains
+% PURPOSE:
+%   wrapper for contains() function, which does not exist on Octave
+%
+% CALLING SEQUENCE:
+%   in=contains(str, pattern)
+% INPUTS:
+%   str: string
+%   pattern: string
+% OUTPUTS:
+%   in: the indices of the points within the polygon (see help inpolygon)
+% MODIFICATION HISTORY:
+% Mark Westcott, mark.westcott@vivideconomics.com, 20180622, initial
+
+global climada_global
+if ~climada_init_vars,return;end % init/import global variables
+
+
+if ~climada_global.octave_mode
+  TF = contains(str,pattern); % MATLAB
+else
+
+  if(  (!(ischar (str) && isvector (str))) && (!ischar(str) && !iscellstr(str)) )
+    error("Search term should be a character vector, or cell array of character vectors.");
+  end;
+
+  if (!iscellstr(str))
+    str = cellstr(str);
+  end
+
+  TF = cellfun(@numel, strfind (str, pattern));
+  
+ end


### PR DESCRIPTION
Add climada_contains() function, which wraps contains() on Matlab, but provides an implementation on Octave which is missing this function. I tested my implementation against Matlab's function and outputs are the same for the same input. 

I'll create a separate pull request on the European storm module to use this function instead of contains().